### PR TITLE
rpc: add eth_callMany

### DIFF
--- a/cmd/rpcdaemon/commands/eth_callMany.go
+++ b/cmd/rpcdaemon/commands/eth_callMany.go
@@ -241,9 +241,6 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 		}
 		if bundle.BlockOverride.BlockHash != nil {
 			for blockNum, hash := range *bundle.BlockOverride.BlockHash {
-				if err != nil {
-					return nil, err
-				}
 				overrideBlockHash[blockNum] = hash
 			}
 		}

--- a/cmd/rpcdaemon/commands/eth_callMany_test.go
+++ b/cmd/rpcdaemon/commands/eth_callMany_test.go
@@ -1,0 +1,165 @@
+package commands
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strconv"
+	"testing"
+
+	"github.com/ledgerwatch/erigon-lib/kv/kvcache"
+	"github.com/ledgerwatch/erigon/accounts/abi/bind"
+	"github.com/ledgerwatch/erigon/accounts/abi/bind/backends"
+	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/commands/contracts"
+	"github.com/ledgerwatch/erigon/common/hexutil"
+	"github.com/ledgerwatch/erigon/core"
+	"github.com/ledgerwatch/erigon/crypto"
+	"github.com/ledgerwatch/erigon/internal/ethapi"
+	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/erigon/rpc"
+	"github.com/ledgerwatch/erigon/turbo/snapshotsync"
+)
+
+// block 1 contains 3 Transactions
+//	 1. deploy token A
+//	 2. mint address 2 100 token
+//	 3. transfer from address 2 to address 1
+
+// test 2 bundles
+// check balance of addr1 and addr 2 at the end of block and interblock
+
+func TestCallMany(t *testing.T) {
+	var (
+		key, _   = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		key1, _  = crypto.HexToECDSA("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee")
+		key2, _  = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+		address  = crypto.PubkeyToAddress(key.PublicKey)
+		address1 = crypto.PubkeyToAddress(key1.PublicKey)
+		address2 = crypto.PubkeyToAddress(key2.PublicKey)
+		gspec    = &core.Genesis{
+			Config: params.AllEthashProtocolChanges,
+			Alloc: core.GenesisAlloc{
+				address:  {Balance: big.NewInt(9000000000000000000)},
+				address1: {Balance: big.NewInt(200000000000000000)},
+				address2: {Balance: big.NewInt(300000000000000000)},
+			},
+			GasLimit: 10000000,
+		}
+		chainID = big.NewInt(1337)
+		ctx     = context.Background()
+
+		addr1BalanceCheck = "70a08231" + "000000000000000000000000" + address1.Hex()[2:]
+		addr2BalanceCheck = "70a08231" + "000000000000000000000000" + address2.Hex()[2:]
+		transferAddr2     = "70a08231" + "000000000000000000000000" + address1.Hex()[2:] + "0000000000000000000000000000000000000000000000000000000000000064"
+	)
+
+	hexBytes, _ := hex.DecodeString(addr2BalanceCheck)
+	balanceCallAddr2 := hexutil.Bytes(hexBytes)
+	hexBytes, _ = hex.DecodeString(addr1BalanceCheck)
+	balanceCallAddr1 := hexutil.Bytes(hexBytes)
+	hexBytes, _ = hex.DecodeString(transferAddr2)
+	transferCallData := hexutil.Bytes(hexBytes)
+
+	//submit 3 Transactions and commit the results
+	transactOpts, _ := bind.NewKeyedTransactorWithChainID(key, chainID)
+	transactOpts1, _ := bind.NewKeyedTransactorWithChainID(key1, chainID)
+	transactOpts2, _ := bind.NewKeyedTransactorWithChainID(key2, chainID)
+	contractBackend := backends.NewSimulatedBackendWithConfig(gspec.Alloc, gspec.Config, gspec.GasLimit)
+	defer contractBackend.Close()
+	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
+	tokenAddr, _, tokenContract, _ := contracts.DeployToken(transactOpts, contractBackend, address1)
+	tokenContract.Mint(transactOpts1, address2, big.NewInt(100))
+	tokenContract.Transfer(transactOpts2, address1, big.NewInt(100))
+	contractBackend.Commit()
+
+	// set up the callargs
+	var nonce hexutil.Uint64 = 1
+	var secondNonce hexutil.Uint64 = 2
+
+	db := contractBackend.DB()
+	api := NewEthAPI(NewBaseApi(nil, stateCache, snapshotsync.NewBlockReader(), false), db, nil, nil, nil, 5000000)
+
+	callArgAddr1 := ethapi.CallArgs{From: &address, To: &tokenAddr, Nonce: &nonce,
+		MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(1e9)),
+		MaxFeePerGas:         (*hexutil.Big)(big.NewInt(1e10)),
+		Data:                 &balanceCallAddr1,
+	}
+	callArgAddr2 := ethapi.CallArgs{From: &address, To: &tokenAddr, Nonce: &secondNonce,
+		MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(1e9)),
+		MaxFeePerGas:         (*hexutil.Big)(big.NewInt(1e10)),
+		Data:                 &balanceCallAddr2,
+	}
+
+	callArgTransferAddr2 := ethapi.CallArgs{From: &address2, To: &tokenAddr, Nonce: &nonce,
+		MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(1e9)),
+		MaxFeePerGas:         (*hexutil.Big)(big.NewInt(1e10)),
+		Data:                 &transferCallData,
+	}
+
+	timeout := int64(50000)
+	txIndex := -1
+	res, err := api.CallMany(ctx, []Bundle{{
+		Transactions: []ethapi.CallArgs{callArgAddr1, callArgAddr2}}}, StateContext{BlockNumber: rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber), TransactionIndex: &txIndex}, &timeout)
+	if err != nil {
+		t.Errorf("eth_callMany: %v", err)
+	}
+
+	// parse the results and do balance checks
+	addr1CalRet := fmt.Sprintf("%v", res[0][0]["value"])[2:]
+	addr2CalRet := fmt.Sprintf("%v", res[0][1]["value"])[2:]
+	addr1Balance, err := strconv.ParseInt(addr1CalRet, 16, 64)
+	if err != nil {
+		t.Errorf("eth_callMany: %v", err)
+	}
+	addr2Balance, err := strconv.ParseInt(addr2CalRet, 16, 64)
+
+	if err != nil {
+		t.Errorf("eth_callMany: %v", err)
+	}
+	if addr1Balance != 100 || addr2Balance != 0 {
+		t.Errorf("eth_callMany: %v", "balanceUnmatch")
+	}
+
+	txIndex = 2
+	res, err = api.CallMany(ctx, []Bundle{{
+		Transactions: []ethapi.CallArgs{callArgAddr1, callArgAddr2}}}, StateContext{BlockNumber: rpc.BlockNumberOrHashWithNumber(1), TransactionIndex: &txIndex}, &timeout)
+	if err != nil {
+		t.Errorf("eth_callMany: %v", err)
+	}
+
+	addr1CalRet = fmt.Sprintf("%v", res[0][0]["value"])[2:]
+	addr2CalRet = fmt.Sprintf("%v", res[0][1]["value"])[2:]
+	addr1Balance, err = strconv.ParseInt(addr1CalRet, 16, 64)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	addr2Balance, err = strconv.ParseInt(addr2CalRet, 16, 64)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	if addr1Balance != 0 || addr2Balance != 100 {
+		t.Errorf("eth_callMany: %s", "balanceUnmatch")
+	}
+	txIndex = -1
+	res, err = api.CallMany(ctx, []Bundle{{Transactions: []ethapi.CallArgs{callArgTransferAddr2, callArgAddr1, callArgAddr2}}}, StateContext{BlockNumber: rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber), TransactionIndex: &txIndex}, &timeout)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	addr1CalRet = fmt.Sprintf("%v", res[0][1]["value"])[2:]
+	addr2CalRet = fmt.Sprintf("%v", res[0][2]["value"])[2:]
+
+	addr1Balance, err = strconv.ParseInt(addr1CalRet, 16, 64)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	addr2Balance, err = strconv.ParseInt(addr2CalRet, 16, 64)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if addr1Balance != 100 || addr2Balance != 0 {
+		t.Errorf("eth_callMany: %s", "balanceUnmatch")
+	}
+}


### PR DESCRIPTION
For this PR, I implemented `callIntraBundle` to simulate bundles at an arbitrary blockchain index and its corresponding testing suite `eth_block_test.go`. 


For a sample python test,

```
import json
import requests
url = "http://127.0.0.1:8545"
headers = {"content-type": "application/json"}

reserveTx = {
    "from": "0xB283366D2AF84036e76b1166A7395A735435baFD",
    "to": "0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc",
    "nonce": "0x0",
    "gas": "0x13880",
    'maxPriorityFeePerGas': "0x59682f00",
    'maxFeePerGas': "0x28ade5e73c",
    "value": "0x0",
    'type': '0x2',
    "data": "0x0902f1ac"
}
params = [
    [{"txs": [reserveTx],"stateOverride" : {
        "0xB283366D2AF84036e76b1166A7395A735435baFD": {
            "balance": "0xde0b6b3a7640000"
        }
    }}],  # bundles  # bundle
    {"BlockNumberOrHash": 14917087, "transactionIndex": 234},  # simulationContxt
    500 * 100,  # timeoff
]
payload = json.dumps(
    {"jsonrpc": "2.0", "id": 2, "method": "eth_callIntraBundle", "params": params}
)
r = requests.post(url, payload, headers=headers)
r.content
```

Using this testing script, we could obtain the reserves of USD-ETH UNI V2 Pair. Since it's highly liquid, there are multiple sync events in the same block. With the intra-block simulation, we could get the intermediate reserves. 